### PR TITLE
cm: Sync the new cryptfs_hw repo

### DIFF
--- a/snippets/cm.xml
+++ b/snippets/cm.xml
@@ -2,8 +2,6 @@
 <manifest>
 
   <!-- LineageOS additions -->
-  <project path="external/ahbottomnavigation" name="LineageOS/android_external_ahbottomnavigation" />
-  <project path="external/android-visualizer" name="LineageOS/android_external_android-visualizer" />
   <project path="external/bash" name="LineageOS/android_external_bash" />
   <project path="external/cmsdk-api-coverage" name="LineageOS/android_external_cmsdk-api-coverage" />
   <project path="external/exfat" name="LineageOS/android_external_exfat" />
@@ -40,7 +38,6 @@
   <project path="packages/apps/CMBugReport" name="LineageOS/android_packages_apps_CMBugreport" />
   <project path="packages/apps/CMFileManager" name="LineageOS/android_packages_apps_CMFileManager" />
   <project path="packages/apps/CMUpdater" name="LineageOS/android_packages_apps_CMUpdater" />
-  <project path="packages/apps/CMWallpapers" name="LineageOS/android_packages_apps_CMWallpapers" />
   <project path="packages/apps/Eleven" name="LineageOS/android_packages_apps_Eleven" />
   <project path="packages/apps/Exchange" name="LineageOS/android_packages_apps_Exchange" />
   <project path="packages/apps/FMRadio" name="LineageOS/android_packages_apps_FMRadio" />
@@ -110,6 +107,7 @@
   <project path="system/qcom" name="LineageOS/android_system_qcom" groups="qcom" />
   <project path="vendor/codeaurora/telephony" name="LineageOS/android_vendor_codeaurora_telephony" remote="github" revision="cm-14.1_prerebase" />
   <project path="vendor/qcom/opensource/bluetooth" name="LineageOS/android_vendor_qcom_opensource_bluetooth" remote="github" revision="cm-14.1_prerebase" />
+  <project path="vendor/qcom/opensource/cryptfs_hw" name="LineageOS/android_vendor_qcom_opensource_cryptfs_hw" />
   <project path="vendor/qcom/opensource/dataservices" name="LineageOS/android_vendor_qcom_opensource_dataservices" remote="github" revision="cm-14.1_prerebase" />
   <project path="vendor/qcom/opensource/dpm" name="LineageOS/android_vendor_qcom_opensource_dpm" remote="github" revision="cm-14.1_prerebase" />
   <project path="vendor/qcom/opensource/time-services" name="LineageOS/android_vendor_qcom_opensource_time-services" />


### PR DESCRIPTION
It has been moved out of device/qcom/common.

Change-Id: Ic6f09fffa3b8ec32c9743d96f8dd73089741b151