### PR TITLE
cm: Remove ahbottomnavigation library

### DIFF
--- a/snippets/cm.xml
+++ b/snippets/cm.xml
@@ -2,8 +2,7 @@
 <manifest>
 
   <!-- LineageOS additions -->
-  <project path="external/ahbottomnavigation" name="LineageOS/android_external_ahbottomnavigation" />
-  <project path="external/android-visualizer" name="LineageOS/android_external_android-visualizer" />
+
   <project path="external/bash" name="LineageOS/android_external_bash" />
   <project path="external/cmsdk-api-coverage" name="LineageOS/android_external_cmsdk-api-coverage" />
   <project path="external/exfat" name="LineageOS/android_external_exfat" />
@@ -36,11 +35,9 @@
   <project path="hardware/ti/wlan" name="LineageOS/android_hardware_ti_wlan" />
   <project path="hardware/ti/wpan" name="LineageOS/android_hardware_ti_wpan" />
   <project path="packages/apps/AudioFX" name="LineageOS/android_packages_apps_AudioFX" />
-  <project path="packages/apps/Browser" name="LineageOS/android_packages_apps_Browser" />
   <project path="packages/apps/CMBugReport" name="LineageOS/android_packages_apps_CMBugreport" />
   <project path="packages/apps/CMFileManager" name="LineageOS/android_packages_apps_CMFileManager" />
   <project path="packages/apps/CMUpdater" name="LineageOS/android_packages_apps_CMUpdater" />
-  <project path="packages/apps/CMWallpapers" name="LineageOS/android_packages_apps_CMWallpapers" />
   <project path="packages/apps/Eleven" name="LineageOS/android_packages_apps_Eleven" />
   <project path="packages/apps/Exchange" name="LineageOS/android_packages_apps_Exchange" />
   <project path="packages/apps/FMRadio" name="LineageOS/android_packages_apps_FMRadio" />
@@ -110,6 +107,7 @@
   <project path="system/qcom" name="LineageOS/android_system_qcom" groups="qcom" />
   <project path="vendor/codeaurora/telephony" name="LineageOS/android_vendor_codeaurora_telephony" />
   <project path="vendor/qcom/opensource/bluetooth" name="LineageOS/android_vendor_qcom_opensource_bluetooth" />
+  <project path="vendor/qcom/opensource/cryptfs_hw" name="LineageOS/android_vendor_qcom_opensource_cryptfs_hw" />
   <project path="vendor/qcom/opensource/dataservices" name="LineageOS/android_vendor_qcom_opensource_dataservices" />
   <project path="vendor/qcom/opensource/dpm" name="LineageOS/android_vendor_qcom_opensource_dpm" />
   <project path="vendor/qcom/opensource/time-services" name="LineageOS/android_vendor_qcom_opensource_time-services" />


### PR DESCRIPTION
We aren't currently using this. The only reason why this was
being synced, was because it's a dependency of the rebased
Gallery app.

Since the Gallery rebase is currently stalled, remove the library
for now.

This essentially reverts commit 58a7613899d1e4aeec65178a9f0da19ef181f475.

Change-Id: I029979484ec3c695aebbe90eb2a32fc23aaa24f1